### PR TITLE
Handling error from calling wait

### DIFF
--- a/lib/runner.go
+++ b/lib/runner.go
@@ -61,7 +61,12 @@ func (r *runner) Kill() error {
 	if r.command != nil && r.command.Process != nil {
 		done := make(chan error)
 		go func() {
-			r.command.Wait()
+			if err := r.command.Wait(); err != nil {
+				// If wait fails to run we kill after a timeout of 3 seconds below, so
+				// this is okay.
+				log.Println("failed to run wait: ", err)
+				return
+			}
 			close(done)
 		}()
 


### PR DESCRIPTION
Calling command.Wait can return an error. This handles that error and prevents
gin from indicating that the process exited when it hasn't.